### PR TITLE
Utilisation d’un objet unicode plutôt que str pour la version.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -56,7 +56,7 @@ copyright = u'2014, Yannick Copin <y.copin(at)ipnl.in2p3.fr>'
 # built documents.
 #
 # The short X.Y version.
-version = 'École Normale Supérieure de Lyon - DSM-L3'
+version = u'École Normale Supérieure de Lyon - DSM-L3'
 # The full version, including alpha/beta/rc tags.
 release = '2014'
 


### PR DESCRIPTION
L’utilisation d’un objet str fait planter ma version de Sphinx à cause du caractère accentué.